### PR TITLE
Provide FDW query time profiles

### DIFF
--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -77,7 +77,7 @@ typedef struct PgFdwRelationInfo
 	bool		use_remote_estimate;
 	Cost		fdw_startup_cost;
 	Cost		fdw_tuple_cost;
-	
+
 	/* Cached catalog information. */
 	ForeignTable *table;
 	ForeignServer *server;
@@ -1025,10 +1025,10 @@ postgresIterateForeignScan(ForeignScanState *node)
 	 * cursor on the remote side.
 	 */
 	if (!fsstate->cursor_exists)
-    {
+	{
 		gettimeofday(&(fsstate->start_time), NULL);
 		create_cursor(node);
-    }
+	}
 
 	/*
 	 * Get some more tuples, if we've run out.


### PR DESCRIPTION
Profile info is written to debug, so to see them you have to turn on display:

```
contrib_regression=# set client_min_messages = debug1;
```

And to compare to overall times, you have to enable overall timing:

```
contrib_regression=# \timing
```

And then you can see and compare:

```
contrib_regression=# SELECT count(c3) FROM ft1 t1 WHERE t1.c1 === t1.c2;
DEBUG:  FDW Query Duration: 5.853 ms
 count 
-------
     6
(1 row)

Time: 7.189 ms
```
