### PR TITLE
Make execution of plpython interruptible

### DIFF
--- a/src/pl/plpython/plpy_main.c
+++ b/src/pl/plpython/plpy_main.c
@@ -74,12 +74,18 @@ PyObject   *PLy_interp_globals = NULL;
 /* this doesn't need to be global; use PLy_current_execution_context() */
 static PLyExecutionContext *PLy_execution_contexts = NULL;
 
++/* postgres backend handler for interruption */
++static pqsigfunc coreIntHandler = 0;
++static void PLy_handle_interrupt(int sig);
 
 void
 _PG_init(void)
 {
 	int		  **bitmask_ptr;
 	const int **version_ptr;
+
+	/* Catch and process SIGINT signals */
+	coreIntHandler = pqsignal(SIGINT, PLy_handle_interrupt);
 
 	/*
 	 * Set up a shared bitmask variable telling which Python version(s) are
@@ -425,6 +431,9 @@ PLy_current_execution_context(void)
 	return PLy_execution_contexts;
 }
 
+/* Indicate tha a python interruption is pending */
+static int PLy_pending_interrupt = 0;
+
 static PLyExecutionContext *
 PLy_push_execution_context(void)
 {
@@ -451,6 +460,47 @@ PLy_pop_execution_context(void)
 
 	PLy_execution_contexts = context->next;
 
+	if (PLy_execution_contexts == NULL) {
+		// Clear pending interrupts when top level context exits
+		PLy_pending_interrupt = 0;
+	}
+
 	MemoryContextDelete(context->scratch_ctx);
 	PLy_free(context);
+}
+
+void _PG_fini(void);
+void
+_PG_fini(void)
+{
+	// Restore previous SIGINT handler
+	pqsignal(SIGINT, coreIntHandler);
+}
+
+static int
+PLy_python_interruption_handler()
+{
+	if (!PLy_pending_interrupt) {
+		return 0;
+	}
+
+	PLy_pending_interrupt = 0;
+	PyErr_SetString(PyExc_RuntimeError, "Execution of function interrupted by signal");
+	return -1;
+}
+
+static void
+PLy_handle_interrupt(int sig)
+{
+	if (PLy_execution_contexts != NULL && !PLy_pending_interrupt) {
+		PLy_pending_interrupt = 1;
+		Py_AddPendingCall(PLy_python_interruption_handler, NULL);
+	}
+	// Fallback to execute prior handlers
+	if (coreIntHandler != SIG_DFL && coreIntHandler != SIG_IGN) {
+		// There's a catch here: if the prior handler was SIG_DFL we have no easy way
+		// of invoking it here;
+		// As that's an unlikely situation we'll just treat SIG_DFL as SIG_IGN.
+		(*coreIntHandler)(sig);
+	}
 }


### PR DESCRIPTION
When a postgres process receives a `SIGINT`, the default behaviour (handled by the function `StatementCancelHandle`) it to set up a couple of flags to indicate the occurrence of the interrupt and hopefully cancel ongoing queries.

Since execution of PLPython functions does not check those flags, the execution of long-running code may go uninterrupted.

This was discussed [here](https://www.postgresql.org/message-id/flat/CAFYwGJ3%2BXg7EcL2nU-MxX6p%2BO6c895Pm3mYZ-b%2B9n9DffEh5MQ%40mail.gmail.com#CAFYwGJ3+Xg7EcL2nU-MxX6p+O6c895Pm3mYZ-b+9n9DffEh5MQ@mail.gmail.com).

This patch makes execution of PLPython interruptible by hooking into the PostgreSQL signal-handling mechanism with `pqsignal` (like for example PostGIS also does) and inserting a pending call into the Python VM to generate a Python exception.

Execution could still go uninterrupted if for example long-running external code is called.

## Acknowledgements

It was @ethervoid who initially investigated this problem and designed this solution.

## Notes on the implementation

Care is taken to avoid inserting or executing python interruptions outside of the proper PLPython contexts. (plpython contexts can be nested as plpython functions are executed through SPI).

* If PLPython is not being executed when the signal is received no interruption is inserted
* If the top level plpython context when the signal is received finishes, pending interruptions are ignored.

Thus we prevent interruptions being effective in later, unrelated queries or commands.

Note also that the python pending call handler must return -1 when an interruption is generated;
failing to do so would cause the interruption to be queued for later execution at an indeterminate time.
