### PR TITLE
Allow SQL functions to inline in the presence of costly parameter functions

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4545,7 +4545,7 @@ inline_function(Oid funcid, Oid result_type, Oid result_collid,
 		else if (usecounts[i] != 1)
 		{
 			/* Param used multiple times: uncool if expensive or volatile */
-			QualCost	eval_cost;
+			// QualCost	eval_cost;
 
 			/*
 			 * We define "expensive" as "contains any subplan or more than 10
@@ -4555,10 +4555,10 @@ inline_function(Oid funcid, Oid result_type, Oid result_collid,
 			 */
 			if (contain_subplans(param))
 				goto fail;
-			cost_qual_eval(&eval_cost, list_make1(param), NULL);
-			if (eval_cost.startup + eval_cost.per_tuple >
-				10 * cpu_operator_cost)
-				goto fail;
+			// cost_qual_eval(&eval_cost, list_make1(param), NULL);
+			// if (eval_cost.startup + eval_cost.per_tuple >
+			// 	10 * cpu_operator_cost)
+			// 	goto fail;
 
 			/*
 			 * Check volatility last since this is more expensive than the


### PR DESCRIPTION
Remove parameter function cost tests from the
inline() function, so that PostGIS sql language
functions will correctly inline even when they
have been decorated with higer-than-default costs.
Because the Carto 2.4 PostGIS branch does include
functions decorated with higher costs, this
patch is important to ensure that unindexed
accesses do not occur. The high cost
functions are required to induce the PgSQL
planner to parallelize spatial operations
a little more aggressively than standard
database functions.

This patch will never be applied to PgSQL core, the 
real patch will probably be a more generic fix to allow
costly nodes to be cached during execution.

https://www.postgresql.org/message-id/6480.1510861492@sss.pgh.pa.us

