### PR TITLE
[DNM] Rowexpr fix collations

### DIFF
--- a/contrib/postgres_fdw/connection.c
+++ b/contrib/postgres_fdw/connection.c
@@ -359,8 +359,8 @@ configure_remote_session(PGconn *conn)
 {
 	int			remoteversion = PQserverVersion(conn);
 
-	/* Force the search path to contain only pg_catalog (see deparse.c) */
-	do_sql_command(conn, "SET search_path = pg_catalog");
+	/* Force the search path to contain only pg_catalog & public (see deparse.c) */
+	do_sql_command(conn, "SET search_path = pg_catalog,public");
 
 	/*
 	 * Set remote timezone; this is basically just cosmetic, since all

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -466,7 +466,7 @@ foreign_expr_walker(Node *node,
 				 * If function's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (fe->inputcollid == InvalidOid)
+				if (fe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 fe->inputcollid != inner_cxt.collation)
@@ -514,7 +514,7 @@ foreign_expr_walker(Node *node,
 				 * If operator's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (oe->inputcollid == InvalidOid)
+				if (oe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 oe->inputcollid != inner_cxt.collation)
@@ -554,7 +554,7 @@ foreign_expr_walker(Node *node,
 				 * If operator's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (oe->inputcollid == InvalidOid)
+				if (oe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 oe->inputcollid != inner_cxt.collation)

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -103,6 +103,7 @@ typedef struct deparse_expr_cxt
 								 * a base relation. */
 	StringInfo	buf;			/* output buffer to append to */
 	List	  **params_list;	/* exprs that will become remote Params */
+	RowExpr   *row_expr;        /* used for later generation of equivalent subquery */
 } deparse_expr_cxt;
 
 #define REL_ALIAS_PREFIX	"r"
@@ -1006,6 +1007,7 @@ deparseSelectStmtForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *rel,
 	context.foreignrel = rel;
 	context.scanrel = IS_UPPER_REL(rel) ? fpinfo->outerrel : rel;
 	context.params_list = params_list;
+	context.row_expr = NULL;
 
 	/* Construct SELECT clause */
 	deparseSelectSql(tlist, is_subquery, retrieved_attrs, &context);
@@ -1132,6 +1134,26 @@ deparseFromExpr(List *quals, deparse_expr_cxt *context)
 
 	/* Construct FROM clause */
 	appendStringInfoString(buf, " FROM ");
+
+	// We have a row expression. Add the corresponding subquery
+	if (context->row_expr) {
+		bool		first;
+		ListCell   *lc;
+		RowExpr    *node = context->row_expr;
+
+		appendStringInfoString(buf, "(SELECT ");
+		first = true;
+		foreach(lc, node->args)
+		{
+			if (!first)
+				appendStringInfo(buf, ", ");
+			deparseExpr((Expr *) lfirst(lc), context);
+			first = false;
+		}
+
+		appendStringInfoString(buf, " FROM ");
+	}
+
 	deparseFromExprForRel(buf, context->root, scanrel,
 						  (bms_num_members(scanrel->relids) > 1),
 						  (Index) 0, NULL, context->params_list);
@@ -1141,6 +1163,12 @@ deparseFromExpr(List *quals, deparse_expr_cxt *context)
 	{
 		appendStringInfoString(buf, " WHERE ");
 		appendConditions(quals, context);
+	}
+
+	// Close subquery and add an alias
+	if (context->row_expr) {
+		appendStringInfoString(buf, ") myalias");
+		context->row_expr = NULL;
 	}
 }
 
@@ -2376,19 +2404,12 @@ static void
 deparseRowExpr(RowExpr *node, deparse_expr_cxt *context)
 {
 	StringInfo	buf = context->buf;
-	bool		first;
-	ListCell   *lc;
 
-	appendStringInfoString(buf, "ROW(");
-	first = true;
-	foreach(lc, node->args)
-	{
-		if (!first)
-			appendStringInfo(buf, ", ");
-		deparseExpr((Expr *) lfirst(lc), context);
-		first = false;
-	}
-	appendStringInfoChar(buf, ')');
+	// Add an arbitrary alias
+	appendStringInfoString(buf, "myalias");
+
+	// Just save the node for later generation of subquery
+	context->row_expr = node;
 }
 
 /*

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -466,7 +466,7 @@ foreign_expr_walker(Node *node,
 				 * If function's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (fe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
+				if (fe->inputcollid == InvalidOid)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 fe->inputcollid != inner_cxt.collation)
@@ -514,7 +514,7 @@ foreign_expr_walker(Node *node,
 				 * If operator's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (oe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
+				if (oe->inputcollid == InvalidOid)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 oe->inputcollid != inner_cxt.collation)
@@ -554,7 +554,7 @@ foreign_expr_walker(Node *node,
 				 * If operator's input collation is not derived from a foreign
 				 * Var, it can't be sent to remote.
 				 */
-				if (oe->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
+				if (oe->inputcollid == InvalidOid)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 oe->inputcollid != inner_cxt.collation)

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -2450,7 +2450,6 @@ deparseRowExpr(RowExpr *node, deparse_expr_cxt *context)
 {
 	StringInfo	buf = context->buf;
 	List 	  **row_exprs_list = context->row_exprs_list;
-	elog(NOTICE, "In deparseRowExpr");
 
 	// Just save the node for later generation of subquery
 	*row_exprs_list = lappend(*row_exprs_list, node);

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -785,7 +785,6 @@ foreign_expr_walker(Node *node,
 	    case T_RowExpr:
 			{
 				RowExpr *re = (RowExpr *) node;
-				ListCell   *lc;
 
 				if(re->row_typeid != RECORDOID)
 				{

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -752,7 +752,7 @@ foreign_expr_walker(Node *node,
 				 * If aggregate's input collation is not derived from a
 				 * foreign Var, it can't be sent to remote.
 				 */
-				if (agg->inputcollid == InvalidOid)
+				if (agg->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 agg->inputcollid != inner_cxt.collation)

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -382,11 +382,16 @@ foreign_expr_walker(Node *node,
 				 * non-collation-sensitive context.
 				 */
 				collation = c->constcollid;
-				if (collation == InvalidOid ||
-					collation == DEFAULT_COLLATION_OID)
-					state = FDW_COLLATE_NONE;
-				else
-					state = FDW_COLLATE_UNSAFE;
+				switch(collation) {
+					case InvalidOid:
+						state = FDW_COLLATE_NONE;
+						break;
+					case DEFAULT_COLLATION_OID:
+						state = FDW_COLLATE_SAFE;
+						break;
+					default:
+						state = FDW_COLLATE_UNSAFE;
+				}
 			}
 			break;
 		case T_Param:

--- a/contrib/postgres_fdw/deparse.c
+++ b/contrib/postgres_fdw/deparse.c
@@ -753,7 +753,7 @@ foreign_expr_walker(Node *node,
 				 * If aggregate's input collation is not derived from a
 				 * foreign Var, it can't be sent to remote.
 				 */
-				if (agg->inputcollid == InvalidOid || inner_cxt.state == FDW_COLLATE_NONE)
+				if (agg->inputcollid == InvalidOid)
 					 /* OK, inputs are all noncollatable */ ;
 				else if (inner_cxt.state != FDW_COLLATE_SAFE ||
 						 agg->inputcollid != inner_cxt.collation)

--- a/contrib/postgres_fdw/expected/postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/postgres_fdw.out
@@ -8373,13 +8373,13 @@ DROP TYPE "Colors" CASCADE;
 NOTICE:  drop cascades to column Col of table import_source.t5
 IMPORT FOREIGN SCHEMA import_source LIMIT TO (t5)
   FROM SERVER loopback INTO import_dest5;  -- ERROR
-ERROR:  type "public.Colors" does not exist
-LINE 4:   "Col" public."Colors" OPTIONS (column_name 'Col')
+ERROR:  type "Colors" does not exist
+LINE 4:   "Col" "Colors" OPTIONS (column_name 'Col')
                 ^
 QUERY:  CREATE FOREIGN TABLE t5 (
   c1 integer OPTIONS (column_name 'c1'),
   c2 text OPTIONS (column_name 'c2') COLLATE pg_catalog."C",
-  "Col" public."Colors" OPTIONS (column_name 'Col')
+  "Col" "Colors" OPTIONS (column_name 'Col')
 ) SERVER loopback
 OPTIONS (schema_name 'import_source', table_name 't5');
 CONTEXT:  importing foreign table "t5"


### PR DESCRIPTION
This is a retake of the original patch, with two major changes:
- A much cleaner implementation of RowExpr deparsing, that can work with nested RowExpr.
- A fix for collations of Const, which I believe can be sent without problem when they use default.

As a result, this passes regression tests and causes remote execution of ST_AsMVT, as intended.

What's missing:
- test(s) for the collation fix, if possible at all without the complexities of postgis in the middle.
- tests for RowExpr deparsing. I suspect it may fail in the event of two RowExpr branches because of alias names clashing, but don't even know if that situation can possibly happen.