### PR TITLE
[DNM] postgres_fdw arbitrary queries

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -8,7 +8,7 @@ PG_CPPFLAGS = -I$(libpq_srcdir)
 SHLIB_LINK_INTERNAL = $(libpq)
 
 EXTENSION = postgres_fdw
-DATA = postgres_fdw--1.0.sql
+DATA = postgres_fdw--1.0.sql postgres_fdw--1.0--1.1.sql postgres_fdw--1.1.sql
 
 REGRESS = postgres_fdw
 

--- a/contrib/postgres_fdw/expected/postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/postgres_fdw.out
@@ -8850,3 +8850,23 @@ SELECT * FROM postgres_fdw_query('loopback', $$SELECT table_name, table_type
  T 4        | BASE TABLE
 (4 rows)
 
+-- Test we can send commands (e.g: prepared statements)
+SELECT * FROM postgres_fdw_query('loopback', $$PREPARE fooplan (int) AS
+SELECT $1 + 42$$) AS t(res text);
+   res   
+---------
+ PREPARE
+(1 row)
+
+SELECT * FROM postgres_fdw_query('loopback', 'EXECUTE fooplan (1)') AS t(i int);
+ i  
+----
+ 43
+(1 row)
+
+SELECT * FROM postgres_fdw_query('loopback', 'DEALLOCATE fooplan') AS t(res text);
+    res     
+------------
+ DEALLOCATE
+(1 row)
+

--- a/contrib/postgres_fdw/expected/postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/postgres_fdw.out
@@ -8801,3 +8801,60 @@ SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 
 
 -- Clean-up
 RESET enable_partitionwise_aggregate;
+-- ===================================================================
+-- test postgres_fdw_query(server name, sql text)
+-- ===================================================================
+-- Most simple SELECT through postgres_fdw_query
+SELECT * FROM postgres_fdw_query('loopback', 'SELECT 42') AS t(i int);
+ i  
+----
+ 42
+(1 row)
+
+-- Select the effective role configured in the user mapping
+SELECT * FROM postgres_fdw_query('loopback', 'SELECT current_user')
+  AS t(role_name name);
+ role_name 
+-----------
+ postgres
+(1 row)
+
+-- Select schemas owned by the role configured in the user mapping
+SELECT * FROM postgres_fdw_query('loopback', $$SELECT s.nspname
+    FROM pg_catalog.pg_namespace s
+    JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+    WHERE u.usename = current_user
+    ORDER BY s.nspname$$
+) AS schemas(schema_name name);
+    schema_name     
+--------------------
+ S 1
+ import_dest1
+ import_dest2
+ import_dest3
+ import_dest4
+ import_dest5
+ import_source
+ information_schema
+ pg_catalog
+ pg_temp_1
+ pg_toast
+ pg_toast_temp_1
+ public
+(13 rows)
+
+-- Select tables and views in a given foreign schema that the role
+-- configured in the user mapping has access to
+SELECT * FROM postgres_fdw_query('loopback', $$SELECT table_name, table_type
+    FROM information_schema.tables
+    WHERE table_schema = 'S 1'
+    ORDER BY table_name$$
+) AS schemas(table_name text, table_type text);
+ table_name | table_type 
+------------+------------
+ T 1        | BASE TABLE
+ T 2        | BASE TABLE
+ T 3        | BASE TABLE
+ T 4        | BASE TABLE
+(4 rows)
+

--- a/contrib/postgres_fdw/expected/postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/postgres_fdw.out
@@ -8811,14 +8811,6 @@ SELECT * FROM postgres_fdw_query('loopback', 'SELECT 42') AS t(i int);
  42
 (1 row)
 
--- Select the effective role configured in the user mapping
-SELECT * FROM postgres_fdw_query('loopback', 'SELECT current_user')
-  AS t(role_name name);
- role_name 
------------
- postgres
-(1 row)
-
 -- Select schemas owned by the role configured in the user mapping
 SELECT * FROM postgres_fdw_query('loopback', $$SELECT s.nspname
     FROM pg_catalog.pg_namespace s

--- a/contrib/postgres_fdw/postgres_fdw--1.0--1.1.sql
+++ b/contrib/postgres_fdw/postgres_fdw--1.0--1.1.sql
@@ -1,0 +1,7 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION postgres_fdw" to load this file. \quit
+
+CREATE FUNCTION postgres_fdw_query(server name, sql text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;

--- a/contrib/postgres_fdw/postgres_fdw--1.1.sql
+++ b/contrib/postgres_fdw/postgres_fdw--1.1.sql
@@ -1,0 +1,21 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION postgres_fdw" to load this file. \quit
+
+CREATE FUNCTION postgres_fdw_handler()
+RETURNS fdw_handler
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION postgres_fdw_validator(text[], oid)
+RETURNS void
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION postgres_fdw_query(server name, sql text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER postgres_fdw
+  HANDLER postgres_fdw_handler
+  VALIDATOR postgres_fdw_validator;

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -5909,6 +5909,8 @@ Datum
 postgres_fdw_query(PG_FUNCTION_ARGS)
 {
 	FuncCallContext	 *funcctx;
+	Name              server;
+	text             *sql;
 
 	if (SRF_IS_FIRSTCALL())
 	{
@@ -5917,7 +5919,14 @@ postgres_fdw_query(PG_FUNCTION_ARGS)
 		funcctx = SRF_FIRSTCALL_INIT();
 		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
 		/* One-time setup code appears here: */
-		/* user code */
+
+		// get input args
+		server = PG_GETARG_NAME(0);
+		sql = PG_GETARG_TEXT_P(1);
+
+		elog(DEBUG3, "server = %s", NameStr(*server));
+		elog(DEBUG3, "sql = %s", text_to_cstring(sql));
+
 		/* if returning composite */
 		/*	   build TupleDesc, and perhaps AttInMetadata */
 		/* endif returning composite */

--- a/contrib/postgres_fdw/postgres_fdw.c
+++ b/contrib/postgres_fdw/postgres_fdw.c
@@ -5900,3 +5900,47 @@ find_em_expr_for_rel(EquivalenceClass *ec, RelOptInfo *rel)
 	/* We didn't find any suitable equivalence class expression */
 	return NULL;
 }
+
+
+
+PG_FUNCTION_INFO_V1(postgres_fdw_query);
+
+Datum
+postgres_fdw_query(PG_FUNCTION_ARGS)
+{
+	FuncCallContext	 *funcctx;
+
+	if (SRF_IS_FIRSTCALL())
+	{
+		MemoryContext oldcontext;
+
+		funcctx = SRF_FIRSTCALL_INIT();
+		oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+		/* One-time setup code appears here: */
+		/* user code */
+		/* if returning composite */
+		/*	   build TupleDesc, and perhaps AttInMetadata */
+		/* endif returning composite */
+		/* user code */
+		MemoryContextSwitchTo(oldcontext);
+	}
+
+	/* Each-time setup code appears here: */
+	//user code
+	funcctx = SRF_PERCALL_SETUP();
+
+	/* this is just one way we might test whether we are done: */
+	/* if (funcctx->call_cntr < funcctx->max_calls) */
+	/* { */
+	/*	   /\* Here we want to return another item: *\/ */
+	/*	   user code */
+	/*	   obtain result Datum */
+	/*	   SRF_RETURN_NEXT(funcctx, result); */
+	/* } */
+	/* else */
+	{
+		/* Here we are done returning items and just need to clean up: */
+		//user code
+		SRF_RETURN_DONE(funcctx);
+	}
+}

--- a/contrib/postgres_fdw/postgres_fdw.control
+++ b/contrib/postgres_fdw/postgres_fdw.control
@@ -1,5 +1,5 @@
 # postgres_fdw extension
 comment = 'foreign-data wrapper for remote PostgreSQL servers'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/postgres_fdw'
 relocatable = true

--- a/contrib/postgres_fdw/sql/postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/postgres_fdw.sql
@@ -2416,10 +2416,6 @@ RESET enable_partitionwise_aggregate;
 -- Most simple SELECT through postgres_fdw_query
 SELECT * FROM postgres_fdw_query('loopback', 'SELECT 42') AS t(i int);
 
--- Select the effective role configured in the user mapping
-SELECT * FROM postgres_fdw_query('loopback', 'SELECT current_user')
-  AS t(role_name name);
-
 -- Select schemas owned by the role configured in the user mapping
 SELECT * FROM postgres_fdw_query('loopback', $$SELECT s.nspname
     FROM pg_catalog.pg_namespace s

--- a/contrib/postgres_fdw/sql/postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/postgres_fdw.sql
@@ -2431,3 +2431,9 @@ SELECT * FROM postgres_fdw_query('loopback', $$SELECT table_name, table_type
     WHERE table_schema = 'S 1'
     ORDER BY table_name$$
 ) AS schemas(table_name text, table_type text);
+
+-- Test we can send commands (e.g: prepared statements)
+SELECT * FROM postgres_fdw_query('loopback', $$PREPARE fooplan (int) AS
+SELECT $1 + 42$$) AS t(res text);
+SELECT * FROM postgres_fdw_query('loopback', 'EXECUTE fooplan (1)') AS t(i int);
+SELECT * FROM postgres_fdw_query('loopback', 'DEALLOCATE fooplan') AS t(res text);

--- a/contrib/postgres_fdw/sql/postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/postgres_fdw.sql
@@ -2407,3 +2407,31 @@ SELECT b, avg(a), max(a), count(*) FROM pagg_tab GROUP BY b HAVING sum(a) < 700 
 
 -- Clean-up
 RESET enable_partitionwise_aggregate;
+
+
+-- ===================================================================
+-- test postgres_fdw_query(server name, sql text)
+-- ===================================================================
+
+-- Most simple SELECT through postgres_fdw_query
+SELECT * FROM postgres_fdw_query('loopback', 'SELECT 42') AS t(i int);
+
+-- Select the effective role configured in the user mapping
+SELECT * FROM postgres_fdw_query('loopback', 'SELECT current_user')
+  AS t(role_name name);
+
+-- Select schemas owned by the role configured in the user mapping
+SELECT * FROM postgres_fdw_query('loopback', $$SELECT s.nspname
+    FROM pg_catalog.pg_namespace s
+    JOIN pg_catalog.pg_user u ON u.usesysid = s.nspowner
+    WHERE u.usename = current_user
+    ORDER BY s.nspname$$
+) AS schemas(schema_name name);
+
+-- Select tables and views in a given foreign schema that the role
+-- configured in the user mapping has access to
+SELECT * FROM postgres_fdw_query('loopback', $$SELECT table_name, table_type
+    FROM information_schema.tables
+    WHERE table_schema = 'S 1'
+    ORDER BY table_name$$
+) AS schemas(table_name text, table_type text);

--- a/doc/src/sgml/postgres-fdw.sgml
+++ b/doc/src/sgml/postgres-fdw.sgml
@@ -443,7 +443,7 @@
   </sect3>
  </sect2>
 
- <sect2>
+ <sect2 id="postgres-fdw-connection-management">
   <title>Connection Management</title>
 
   <para>
@@ -528,7 +528,7 @@
   </para>
  </sect2>
 
- <sect2>
+ <sect2 id="postgres-fdw-execution-environment">
   <title>Remote Query Execution Environment</title>
 
   <para>
@@ -582,6 +582,185 @@
    changing the session-level settings of these parameters; that is likely
    to cause <filename>postgres_fdw</filename> to malfunction.
   </para>
+ </sect2>
+
+ <sect2>
+  <title>Remote Execution of Arbitrary Queries</title>
+
+  <para>
+   In some instances it may be useful to ship queries to a remote server not
+   depending upon the local planning on a foreign table. To that end, <xref
+   linkend="postgres-fdw-query"/> can be used.
+  </para>
+  <para>
+   Mind that <emphasis>it is the user's responsibility</emphasis> to ensure
+   session state is not affected by queries sent through
+   <function>postgres_fdw_query()</function> to the remote server.
+  </para>    
+
+  <refentry id="postgres-fdw-query" xreflabel="postgres_fdw_query">
+   <indexterm>
+    <primary>postgres-fdw</primary>
+  </indexterm>
+
+  <refmeta>
+   <refentrytitle>postgres_fdw_query</refentrytitle>
+   <manvolnum>3</manvolnum>
+  </refmeta>
+
+  <refnamediv>
+   <refname>postgres_fdw_query</refname>
+   <refpurpose>executes a query in a foreign server</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+<synopsis>
+postgres_fdw_query(server name, sql text) returns setof record
+</synopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+   <title>Description</title>
+
+   <para>
+    <function>postgres_fdw_query</function> executes a query (usually a <command>SELECT</command>,
+    but it can be any SQL statement that returns rows) in a foreign server.
+   </para>
+  </refsect1>
+
+  <refsect1>
+   <title>Arguments</title>
+
+   <variablelist>
+    <varlistentry>
+     <term><parameter>server</parameter></term>
+     <listitem>
+      <para>
+       Name of the foreign server to use, defined with
+       <command>CREATE SERVER</command> and accessed with the applicable user
+       mapping.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><parameter>sql</parameter></term>
+     <listitem>
+      <para>
+       The SQL query that you wish to execute in the foreign server,
+       for example <literal>SELECT * FROM foo</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </refsect1>
+
+  <refsect1>
+   <title>Return Value</title>
+
+   <para>
+    The function returns the row(s) produced by the query.  Since
+    <function>postgres_fdw_query</function> can be used with any query, it is
+    declared to return <type>record</type>, rather than specifying any
+    particular set of columns.  This means that you must specify the expected
+    set of columns in the calling query &mdash; otherwise
+    <productname>PostgreSQL</productname> would not know what to expect. Here
+    is an example:
+
+<programlisting>
+SELECT * FROM postgres_fdw_query('foreign_server', $$SELECT table_name,
+table_type
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+    ORDER BY table_name$$
+) AS schemas(table_name text, table_type text);
+</programlisting>
+
+    The <quote>alias</quote> part of the <literal>FROM</literal> clause must
+    specify the column names and types that the function will return.
+   </para>
+  </refsect1>
+
+  <refsect1>
+   <title>Caveats</title>
+
+   <para>
+    The function <function>postgres_fdw_query</function> does not perform any
+    checks on the input <parameter>sql</parameter>.
+   </para>
+
+   <para>
+    It also has the potential to change the state of the remote session. In
+    particular, it is recommended <emphasis>not</emphasis> to change
+    session-level settings and avoid using prepared statements prefixed with
+    <literal>pgsql_fdw_prep_</literal>. Otherwise it can interfere with the
+    regular functioning of <literal>postgres_fdw</literal>. It it is the
+    caller's responsibility not to interfere the session state managed by
+    <literal>postgres_fdw</literal>.
+   </para>
+
+   <para>
+    Please see <xref linkend="postgres-fdw-connection-management" /> and <xref
+    linkend="postgres-fdw-execution-environment" /> to understand how
+    connections and sessions are managed by <literal>postgres_fdw</literal>.
+   </para>
+
+   <para>
+    As an alternative, the older <xref linkend="dblink"/> module offers
+    similar functionality and sessions are managed independently from
+    <literal>postgres_fdw</literal>.
+   </para>
+
+  </refsect1>
+
+  <refsect1>
+   <title>Examples</title>
+
+<screen>
+-- Simple query
+SELECT * FROM postgres_fdw_query('loopback', 'SELECT 42') AS t(i int);
+ i  
+----
+ 42
+(1 row)
+
+-- Retrieve info from the foreign information_schema
+SELECT * FROM postgres_fdw_query('loopback', $$SELECT table_name, table_type
+    FROM information_schema.tables
+    WHERE table_schema = 'S 1'
+    ORDER BY table_name$$
+) AS schemas(table_name text, table_type text);
+ table_name | table_type 
+------------+------------
+ T 1        | BASE TABLE
+ T 2        | BASE TABLE
+ T 3        | BASE TABLE
+ T 4        | BASE TABLE
+(4 rows)
+
+-- Prepared statements
+SELECT * FROM postgres_fdw_query('loopback', $$PREPARE fooplan (int) AS
+SELECT $1 + 42$$) AS t(res text);
+   res   
+---------
+ PREPARE
+(1 row)
+
+SELECT * FROM postgres_fdw_query('loopback', 'EXECUTE fooplan (1)') AS t(i int);
+ i  
+----
+ 43
+(1 row)
+
+SELECT * FROM postgres_fdw_query('loopback', 'DEALLOCATE fooplan') AS t(res text);
+    res     
+------------
+ DEALLOCATE
+(1 row)
+</screen>
+  </refsect1>
+ </refentry>
+  
  </sect2>
 
  <sect2>


### PR DESCRIPTION
A PoC of a function to execute arbitrary queries through a foreign server.

Signature:
```sql
CREATE FUNCTION postgres_fdw_query(server name, sql text)
RETURNS SETOF record
```

Examples of usage:
```sql
SELECT * FROM postgres_fdw_query('cdb_fdw_local_pg11', 'SELECT nspname, nspowner from pg_namespace') AS schemas(schema_name name, owner oid);
    schema_name     | owner 
--------------------+-------
 pg_toast           |    10
 pg_temp_1          |    10
 pg_toast_temp_1    |    10
 pg_catalog         |    10
 public             |    10
 information_schema |    10
 carto_lite         | 16384
(7 rows)
```

```sql
SELECT * FROM postgres_fdw_query('cdb_fdw_local_pg11', 'SELECT 1') ;
ERROR:  a column definition list is required for functions returning "record"
LINE 1: SELECT * FROM postgres_fdw_query('cdb_fdw_local_pg11', 'SELE...
```

```sql
SELECT * FROM postgres_fdw_query('cdb_fdw_local_pg11', 'SELECT 1') AS t1(i int);
 i 
---
 1
(1 row)
```