### PR TITLE
Abort with _exit on pg_dump / pg_restore signal handler

### DIFF
--- a/CHANGELOG.carto.md
+++ b/CHANGELOG.carto.md
@@ -1,4 +1,10 @@
-11.5.2+carto-2
+11.5.3+carto-1
+Release date: 2020-01-09
+
+Changes:
+- [#30](https://github.com/CartoDB/postgres/pull/30): Apply a patch to abort pg_dump / pg_restore using _exit instead of exit to avoid Builder CI stuck processes.
+
+11.5.2+carto-1
 Release date: 2019-10-17
 
 Changes:

--- a/src/bin/pg_dump/parallel.c
+++ b/src/bin/pg_dump/parallel.c
@@ -611,8 +611,14 @@ sigTermHandler(SIGNAL_ARGS)
 		write_stderr("terminated by user\n");
 	}
 
-	/* And die. */
-	exit(1);
+	/*
+	 * We abort the program using _exit because using exit may interfere
+	 * with the function that was running when the interruption came.
+	 * For example, if the running function had acquired an allocation mutex
+	 * before it was interrupted and one of the atexit functions tried to
+	 * deallocate memory, it would block indefinitely.
+	 */
+	_exit(1);
 }
 
 /*


### PR DESCRIPTION
Internal: https://github.com/CartoDB/support/issues/2157
Psql bug: https://www.postgresql.org/message-id/flat/16199-cb2f121146a96f9b%40postgresql.org